### PR TITLE
Fix Scrapping NoneType Error and Continue in case of errors

### DIFF
--- a/iam-ape/iam_ape/aws_iam_actions/scrape_iam_actions.py
+++ b/iam-ape/iam_ape/aws_iam_actions/scrape_iam_actions.py
@@ -88,4 +88,3 @@ def scrape_iam_actions() -> int:
 
 if __name__ == "__main__":
     exit(scrape_iam_actions())
-

--- a/iam-ape/iam_ape/aws_iam_actions/scrape_iam_actions.py
+++ b/iam-ape/iam_ape/aws_iam_actions/scrape_iam_actions.py
@@ -33,7 +33,7 @@ def scrape_iam_actions() -> int:
     for link in tqdm.tqdm(all_links, ncols=70):
         try:
             soup = get_soup(base_url + link[2:])
-            # Avoids 'NoneType' object has no attribute 'string' (example: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsiot1-click.html)
+            # Avoids 'NoneType' object has no attribute 'string'
             if soup.find("code") is None:
                 continue
             service_prefix = soup.find("code").string

--- a/iam-ape/iam_ape/aws_iam_actions/scrape_iam_actions.py
+++ b/iam-ape/iam_ape/aws_iam_actions/scrape_iam_actions.py
@@ -33,6 +33,9 @@ def scrape_iam_actions() -> int:
     for link in tqdm.tqdm(all_links, ncols=70):
         try:
             soup = get_soup(base_url + link[2:])
+            # Avoids 'NoneType' object has no attribute 'string' (example: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsiot1-click.html)
+            if soup.find("code") is None:
+                continue
             service_prefix = soup.find("code").string
             tables = soup.find_all("div", class_="table-contents")
             for table in tables:
@@ -68,7 +71,7 @@ def scrape_iam_actions() -> int:
 
         except AttributeError as e:
             logger.error(f"Error occurred while processing {link} - {e}")
-            raise e
+            continue
 
     logger.info("Done!")
 
@@ -85,3 +88,4 @@ def scrape_iam_actions() -> int:
 
 if __name__ == "__main__":
     exit(scrape_iam_actions())
+


### PR DESCRIPTION
Closes #32 

This PR checks if `soup = get_soup(base_url + link[2:])` is not `None` before continue for avoiding the error: `'NoneType' object has no attribute 'string' in pages like https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsiot1-click.html 

It also changes the except behaviour from raise to continue, so we can know the error but not stoping the whole execution. 

Before:

```bash
Updating AWS IAM actions database...
 49%|███████████████▏               | 214/438 [03:54<04:06,  1.10s/it]ERROR: Error occurred while processing ./list_awsiot1-click.html - 'NoneType' object has no attribute 'string'
 49%|███████████████▏               | 214/438 [03:55<04:07,  1.10s/it]
Traceback (most recent call last):
  File "/opt/homebrew/bin/iam-ape", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/iam_ape/main.py", line 281, in main
    scrape_iam_actions()
  File "/opt/homebrew/lib/python3.11/site-packages/iam_ape/aws_iam_actions/scrape_iam_actions.py", line 71, in scrape_iam_actions
    raise e
  File "/opt/homebrew/lib/python3.11/site-packages/iam_ape/aws_iam_actions/scrape_iam_actions.py", line 36, in scrape_iam_actions
    service_prefix = soup.find("code").string
                     ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'string'
```

After:
```bash
Updating AWS IAM actions database...
100%|███████████████████████████████| 438/438 [08:04<00:00,  1.11s/it]
Done!
```

